### PR TITLE
Porting module over from POC to where it can be used in prod environment

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,11 @@
+name: pre-commit
+
+on: push
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: pre-commit/action@v2.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+.DS_Store
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -1,0 +1,15 @@
+{
+  "default": true,
+  "first-header-h1": false,
+  "first-line-h1": false,
+  "line_length": false,
+  "no-multiple-blanks": false,
+  "fenced-code-language": true,
+  "no-duplicate-header": {
+    "siblings_only": true
+  },
+  "code-block-style": {
+    "style": "fenced"
+  },
+  "single-trailing-newline": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: git://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-merge-conflict
+      - id: detect-private-key
+      - id: trailing-whitespace
+
+  - repo: git://github.com/igorshubovych/markdownlint-cli
+    rev: v0.26.0
+    hooks:
+      - id: markdownlint

--- a/README.md
+++ b/README.md
@@ -1,4 +1,45 @@
 # terraform-aws-cms-ars-saf-ecs-runner
 
 This repo contains a Terraform module which will deploy a scheduled ECS
-task which can run a periodic Inspec scan against an AWS account.
+task which can run a periodic Inspec scan against an AWS account. The module supports following features:
+
+* Run an ECS task and stream output to Cloudwatch
+* Cloudwatch rule to run tasks on a cron based cadence
+* Use a user defined ECR repo to run ECs tasks 
+
+## Usage
+
+```hcl
+module "ecs_saf_runner" {
+  source = "github.com/CMSgov/terraform-aws-cms-ars-saf-ecs-runner"
+  
+  app_name    = "aws-scanner"
+  environment = "prod"
+  
+  task_name                = "CIS-Moderate"
+  ecs_vpc_id               = module.vpc.vpc_id
+  ecs_subnet_ids           = module.vpc.private_subnets
+  repo_url                 = module.ecr.url
+  repo_tag                 = "latest"
+  schedule_task_expression = "cron(30 9 * * ? *)"
+  repo_arn                 = module.ecr.arn
+}
+
+```
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+| aws | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 3.0 |
+
+## Modules
+
+No Modules.

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ task which can run a periodic Inspec scan against an AWS account. The module sup
 
 * Run an ECS task and stream output to Cloudwatch
 * Cloudwatch rule to run tasks on a cron based cadence
-* Use a user defined ECR repo to run ECs tasks 
+* Use a user defined ECR repo to run ECs tasks
 
 ## Usage
 
 ```hcl
 module "ecs_saf_runner" {
   source = "github.com/CMSgov/terraform-aws-cms-ars-saf-ecs-runner"
-  
+
   app_name    = "aws-scanner"
   environment = "prod"
-  
+
   task_name                = "CIS-Moderate"
   ecs_vpc_id               = module.vpc.vpc_id
   ecs_subnet_ids           = module.vpc.private_subnets

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ module "ecs_saf_runner" {
   environment = "prod"
 
   task_name                = "CIS-Moderate"
-  ecs_vpc_id               = module.vpc.vpc_id
-  ecs_subnet_ids           = module.vpc.private_subnets
-  repo_url                 = module.ecr.url
+  ecs_vpc_id               = aws_vpc.myvpc.id
+  ecs_subnet_ids           = [aws_subnet.mysubnet.id]
+  repo_url                 = aws_ecr_repository.ecrrepo.repository_url
   repo_tag                 = "latest"
   schedule_task_expression = "cron(30 9 * * ? *)"
-  repo_arn                 = module.ecr.arn
+  repo_arn                 = aws_ecr_repository.ecrrepo.arn
 }
 
 ```

--- a/main.tf
+++ b/main.tf
@@ -171,8 +171,6 @@ resource "aws_iam_role_policy" "cloudwatch_target_role_policy" {
 }
 
 # ECS Task Role
-# Allows ECS to start the task by decrypting secrets for Chamber
-
 data "aws_iam_policy_document" "task_role_policy_doc" {
   # Allow access to the environment specific app secrets
   statement {
@@ -229,7 +227,7 @@ data "aws_iam_policy_document" "task_execution_role_policy_doc" {
       "ecr:BatchGetImage",
     ]
 
-    resources = [var.cms_ars_repo_arn]
+    resources = [var.repo_arn]
   }
 
   statement {
@@ -299,9 +297,7 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
   }
 }
 
-#
 # ECS task details
-#
 
 resource "aws_ecs_task_definition" "scheduled_task_def" {
   family        = "${var.app_name}-${var.environment}-${var.task_name}"

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,8 @@ resource "aws_kms_key" "log_enc_key" {
 }
 
 resource "aws_ecs_cluster" "inspec_cluster" {
-  name = "inspec"
+  name = "${var.app_name}-inspec"
+
   tags = {
     Environment = var.environment
     Automation  = "Terraform"

--- a/main.tf
+++ b/main.tf
@@ -229,7 +229,7 @@ data "aws_iam_policy_document" "task_execution_role_policy_doc" {
       "ecr:BatchGetImage",
     ]
 
-    resources = [module.cms_ars_repo.arn]
+    resources = [var.cms_ars_repo_arn]
   }
 
   statement {

--- a/main.tf
+++ b/main.tf
@@ -277,7 +277,7 @@ resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
 }
 
 #
-# ECS
+# ECS task details
 #
 
 resource "aws_ecs_task_definition" "scheduled_task_def" {
@@ -304,9 +304,9 @@ resource "aws_ecs_task_definition" "scheduled_task_def" {
         "logDriver": "awslogs",
         "secretOptions": null,
         "options": {
-          "awslogs-group": "/ecs/test/cis-aws",
+          "awslogs-group": "${module.cms_ecs_service.awslogs_group}",
           "awslogs-region": "${data.aws_region.current.name}",
-          "awslogs-stream-prefix": "cis-task"
+          "awslogs-stream-prefix": "${var.app_name}"
         }
       },
     "mountPoints": [],

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,370 @@
+data "aws_ami" "ecs_ami" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-*-amazon-ecs-optimized"]
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "cloudwatch_logs_allow_kms" {
+  statement {
+    sid    = "Enable IAM User Permissions"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root",
+      ]
+    }
+
+    actions = [
+      "kms:*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "Allow logs KMS access"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.us-west-2.amazonaws.com"]
+    }
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    resources = ["*"]
+  }
+}
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name = "my-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs             = ["us-west-2a"]
+  public_subnets  = ["10.0.101.0/24"] // not using but needed for nat, can we use internet gateway?
+  private_subnets = ["10.0.1.0/24"]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  tags = {
+    Automation  = "Terraform"
+    Environment = "Test"
+  }
+}
+
+resource "aws_kms_key" "log_enc_key" {
+  description         = "KMS key for encrypting logs"
+  enable_key_rotation = true
+  policy              = data.aws_iam_policy_document.cloudwatch_logs_allow_kms.json
+
+  tags = {
+    Automation = "Terraform"
+  }
+}
+
+resource "aws_ecs_cluster" "inspec_cluster" {
+  name = "inspec"
+  tags = {
+    Environment = var.environment
+    Automation  = "Terraform"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# ECS service for running inspec profile container
+module "cms_ecs_service" {
+  source = "trussworks/ecs-service/aws"
+
+  name          = "cis-aws"
+  environment   = "test"
+  ecr_repo_arns = [var.cms_ars_repo_arn]
+
+  ecs_cluster = {
+    name = aws_ecs_cluster.inspec_cluster.name,
+    arn  = aws_ecs_cluster.inspec_cluster.arn
+  }
+
+  logs_cloudwatch_retention = 731
+  ecs_vpc_id                = module.vpc.vpc_id
+  ecs_subnet_ids            = module.vpc.private_subnets
+  kms_key_id                = aws_kms_key.log_enc_key.arn
+  ecs_use_fargate           = true
+}
+
+### ECS schedule task ##
+
+### Set up Assume Role policies
+
+locals {
+  name                = "inspec"
+  environment         = "test"
+  task_name           = "aws-moderate-scan"
+  schedule_expression = "cron(30 9 * * ? *)" // run 9:30 everyday
+  // minute, hour, day of month, month, day of week, year
+  //https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+
+  repo_url = "004351505091.dkr.ecr.us-west-2.amazonaws.com/cms-aws-inspec-profile"
+  repo_tag = "1613146248"
+
+}
+
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "ecs_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+
+    effect = "Allow"
+  }
+}
+
+data "aws_iam_policy_document" "events_assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    effect = "Allow"
+  }
+}
+
+### CloudWatch Target IAM
+# Allows CloudWatch Rule to run ECS Task
+
+data "aws_iam_policy_document" "cloudwatch_target_role_policy_doc" {
+  statement {
+    actions   = ["iam:PassRole"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions   = ["ecs:RunTask"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "cloudwatch_target_role" {
+  name               = "cw-target-role-${local.name}-${var.environment}-${var.task_name}"
+  description        = "Role allowing CloudWatch Events to run the task"
+  assume_role_policy = data.aws_iam_policy_document.events_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "cloudwatch_target_role_policy" {
+  name   = "${aws_iam_role.cloudwatch_target_role.name}-policy"
+  role   = aws_iam_role.cloudwatch_target_role.name
+  policy = data.aws_iam_policy_document.cloudwatch_target_role_policy_doc.json
+}
+
+### ECS Task Role
+# Allows ECS to start the task by decrypting secrets for Chamber
+
+data "aws_iam_policy_document" "task_role_policy_doc" {
+  # Allow access to the environment specific app secrets
+  statement {
+    actions = [
+      "ssm:GetParametersByPath",
+    ]
+
+    resources = ["arn:${data.aws_partition.current.partition}:ssm:*:*:parameter/${local.name}-${var.environment}/*"]
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "read_only_everything" {
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  role       = aws_iam_role.task_role.name
+}
+
+resource "aws_iam_role" "task_role" {
+  name               = "ecs-task-role-${local.name}-${var.environment}-${local.task_name}"
+  description        = "Role allowing container definition to execute"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "task_role_policy" {
+  name   = "${aws_iam_role.task_role.name}-policy"
+  role   = aws_iam_role.task_role.name
+  policy = data.aws_iam_policy_document.task_role_policy_doc.json
+}
+
+### ECS Task Execution Role https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html
+# Allows ECS to Pull down the ECR Image and write Logs to CloudWatch
+
+data "aws_iam_policy_document" "task_execution_role_policy_doc" {
+  statement {
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = ["${module.cms_ecs_service.awslogs_group_arn}:*"]
+  }
+
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+    ]
+
+    resources = [module.cms_ars_repo.arn]
+  }
+
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:/${local.name}-${local.environment}*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${local.name}-${local.environment}*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "task_execution_role" {
+  name               = "ecs-task-exec-role-${local.name}-${local.environment}-${local.task_name}"
+  description        = "Role allowing ECS tasks to execute"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role_policy.json
+}
+
+resource "aws_iam_role_policy" "task_execution_role_policy" {
+  name   = "${aws_iam_role.task_execution_role.name}-policy"
+  role   = aws_iam_role.task_execution_role.name
+  policy = data.aws_iam_policy_document.task_execution_role_policy_doc.json
+}
+
+#
+# CloudWatch
+#
+
+resource "aws_cloudwatch_event_rule" "run_command" {
+  name                = "${local.task_name}-${local.environment}"
+  description         = "Scheduled task for ${local.task_name} in ${local.environment}"
+  schedule_expression = local.schedule_expression
+}
+
+resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {
+  target_id = "run-scheduled-task-${local.task_name}-${local.environment}"
+  arn       = aws_ecs_cluster.inspec_cluster.arn
+  rule      = aws_cloudwatch_event_rule.run_command.name
+  role_arn  = aws_iam_role.cloudwatch_target_role.arn
+
+  ecs_target {
+    launch_type = "FARGATE"
+    task_count  = 1
+
+    # Use latest active revision
+    task_definition_arn = aws_ecs_task_definition.scheduled_task_def.arn
+
+    network_configuration {
+      subnets          = module.vpc.private_subnets
+      security_groups  = [module.cms_ecs_service.ecs_security_group_id]
+      assign_public_ip = false
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [ecs_target[0].task_definition_arn]
+  }
+}
+
+#
+# ECS
+#
+
+resource "aws_ecs_task_definition" "scheduled_task_def" {
+  family        = "${local.name}-${local.environment}-${local.task_name}"
+  network_mode  = "awsvpc"
+  task_role_arn = aws_iam_role.task_role.arn
+
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "1024"
+  execution_role_arn       = join("", aws_iam_role.task_execution_role.*.arn)
+
+  container_definitions = <<DEFINITION
+[
+  {
+    "name": "${local.name}-${local.environment}-${local.task_name}",
+    "image": "${local.repo_url}:${local.repo_tag}",
+    "cpu": 128,
+    "memory": 1024,
+    "essential": true,
+    "portMappings": [],
+    "environment": [],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "secretOptions": null,
+        "options": {
+          "awslogs-group": "/ecs/test/cis-aws",
+          "awslogs-region": "${data.aws_region.current.name}",
+          "awslogs-stream-prefix": "cis-task"
+        }
+      },
+    "mountPoints": [],
+    "volumesFrom": [],
+    "entryPoint": [
+            "inspec",
+            "exec",
+            "profiles/cms-ars-3.1-moderate-aws-foundations-cis-overlay",
+            "--target",
+            "aws://",
+            "--chef-license",
+            "accept-silent",
+            "--no-color"
+          ]
+  }
+]
+DEFINITION
+}
+
+# Create a data source to pull the latest active revision from
+data "aws_ecs_task_definition" "scheduled_task_def" {
+  task_definition = aws_ecs_task_definition.scheduled_task_def.family
+  depends_on      = [aws_ecs_task_definition.scheduled_task_def] # ensures at least one task def exists
+}
+
+

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ data "aws_iam_policy_document" "cloudwatch_logs_allow_kms" {
 
     principals {
       type        = "Service"
-      identifiers = ["logs.us-west-2.amazonaws.com"]
+      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
     }
 
     actions = [

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,31 @@
+variable "app_name" {
+  type = string
+  description = "Name of the application"
+}
+
+variable "task_name" {
+  type = string
+  description = "Name of the task to be run"
+}
+
+variable "cms_ars_repo_arn" {
+  type        = string
+  description = "Arn of the ecr repo hosting the scanner container image"
+}
+
+variable "environment" {
+  type = string
+  description = "Environment name"
+}
+
+variable "tags" {
+  type        = map(any)
+  description = "Additional tags to apply."
+  default     = {}
+}
+
+variable "scan_on_push" {
+  type        = bool
+  description = "Scan image on push to repo."
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,18 @@ variable "ecs_subnet_ids" {
   type        = list(string)
 }
 
+variable "logs_cloudwatch_retention" {
+  description = "Number of days you want to retain log events in the log group"
+  default = 732 //  two years
+  type = number
+}
+
+variable "logs_cloudwatch_group" {
+  description = "CloudWatch log group to create and use. Default: /ecs/{app_name}-{environment}"
+  default     = ""
+  type        = string
+}
+
 variable "repo_url" {
   type = string
   description = "The url of the ECR repo to pull images and run in ecs"

--- a/variables.tf
+++ b/variables.tf
@@ -67,4 +67,4 @@ variable "scan_on_push" {
   type        = bool
   description = "Scan image on push to repo."
   default     = true
-}v
+}

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,33 @@ variable "task_name" {
   description = "Name of the task to be run"
 }
 
+variable "ecs_vpc_id" {
+  description = "VPC ID to be used by ECS."
+  type        = string
+}
+
+variable "ecs_subnet_ids" {
+  description = "Subnet IDs for the ECS tasks."
+  type        = list(string)
+}
+
+variable "repo_url" {
+  type = string
+  description = "The url of the ECR repo to pull images and run in ecs"
+}
+
+variable "repo_tag" {
+  type = string
+  description = "The tag to identify and pull the image in ECR repo"
+  default = "latest"
+}
+
+variable "schedule_task_expression" {
+  type = string
+  description = "Cron based schedule task to run on a cadence"
+  default = "cron(30 9 * * ? *)" // run 9:30 everyday"
+}
+
 variable "cms_ars_repo_arn" {
   type        = string
   description = "Arn of the ecr repo hosting the scanner container image"
@@ -28,4 +55,4 @@ variable "scan_on_push" {
   type        = bool
   description = "Scan image on push to repo."
   default     = true
-}
+}v

--- a/variables.tf
+++ b/variables.tf
@@ -47,7 +47,7 @@ variable "schedule_task_expression" {
   default = "cron(30 9 * * ? *)" // run 9:30 everyday"
 }
 
-variable "cms_ars_repo_arn" {
+variable "repo_arn" {
   type        = string
   description = "Arn of the ecr repo hosting the scanner container image"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
This PR aims to convert the POC work we did to validate if inspec scans can be run in ECS as scheduled tasks into a module that can be deployed with configurations in order to run ecs tasks.